### PR TITLE
fix: 로그인 실패 핸들링 불가에 따른 fixed.

### DIFF
--- a/src/main/java/com/liberty52/admin/global/adapter/feign/AuthServiceClient.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/AuthServiceClient.java
@@ -19,8 +19,9 @@ import java.util.Set;
 @FeignClient(value = "auth", primary = false)
 public interface AuthServiceClient {
 
-    @PostMapping("/login")
-    ResponseEntity<AdminLoginResponseDto> login(@RequestBody AdminLoginRequestDto dto);
+    @PostMapping(value = "/login")
+    @ResponseStatus(HttpStatus.OK)
+    ResponseEntity<AdminLoginResponseDto> login(AdminLoginRequestDto dto);
 
     @GetMapping(value = "/my")
     AuthProfileDto getAuthProfile(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId);

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/error/Feign4xxException.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/error/Feign4xxException.java
@@ -8,4 +8,7 @@ public class Feign4xxException extends FeignClientException {
     public Feign4xxException(FeignErrorCode errorCode, String causeError) {
         super(errorCode, causeError);
     }
+    public Feign4xxException(FeignErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignClientException.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignClientException.java
@@ -21,6 +21,14 @@ public class FeignClientException extends RuntimeException implements ErrorCode 
         this.causeError = causeError;
     }
 
+    public FeignClientException(FeignErrorCode code) {
+        this.httpStatus = code.getHttpStatus();
+        this.errorCode = code.getErrorCode();
+        this.errorName = code.getErrorName();
+        this.errorMessage = code.getErrorMessage();
+        this.causeError = null;
+    }
+
     public FeignClientException(String causeError) {
         this(FeignErrorCode.ERROR_UNKNOWN, causeError);
     }

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignErrorCode.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum FeignErrorCode implements ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "FEIGN_ERROR - 다시 로그인 후 시도해주세요."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "FEIGN_ERROR - 로그인이 안 되어있거나 실패하였습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FEIGN_ERROR - 접근할 권한이 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "FEIGN_ERROR - 잘못된 요청입니다."),
     ERROR_4XX(HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignRestExceptionHandler.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignRestExceptionHandler.java
@@ -11,8 +11,11 @@ public class FeignRestExceptionHandler {
 
     @ExceptionHandler(FeignClientException.class)
     public ResponseEntity<ErrorResponse> handleFeignClientException(FeignClientException ex, HttpServletRequest request) {
-        return ResponseEntity.status(ex.getHttpStatus())
-                .body(ErrorResponse.createErrorResponse(ex, request.getRequestURI(), ex.getCauseError()));
+        return ex.getCauseError() != null ?
+                ResponseEntity.status(ex.getHttpStatus())
+                        .body(ErrorResponse.createErrorResponse(ex, request.getRequestURI(), ex.getCauseError())) :
+                ResponseEntity.status(ex.getHttpStatus())
+                        .body(ErrorResponse.createErrorResponse(ex, request.getRequestURI()));
     }
 
 }

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignUnauthorizedException.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/error/FeignUnauthorizedException.java
@@ -4,4 +4,7 @@ public class FeignUnauthorizedException extends Feign4xxException {
     public FeignUnauthorizedException(String causeError) {
         super(FeignErrorCode.UNAUTHORIZED, causeError);
     }
+    public FeignUnauthorizedException() {
+        super(FeignErrorCode.UNAUTHORIZED);
+    }
 }

--- a/src/main/java/com/liberty52/admin/global/exception/external/ErrorResponse.java
+++ b/src/main/java/com/liberty52/admin/global/exception/external/ErrorResponse.java
@@ -39,7 +39,10 @@ public class ErrorResponse {
 
     public static ErrorResponse createErrorResponse(ErrorCode errorCode, String path, String causeError) {
         try {
-            ErrorResponse cause = new ObjectMapper().readValue(causeError, ErrorResponse.class);
+            ErrorResponse cause = null;
+            if (causeError != null && !causeError.isBlank()) {
+                cause = new ObjectMapper().readValue(causeError, ErrorResponse.class);
+            }
             return new ErrorResponse(LocalDateTime.now().toString(),errorCode.getHttpStatus(),errorCode.getErrorCode()
                     , errorCode.getErrorName(), errorCode.getErrorMessage(),path, cause);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/liberty52/admin/service/applicationservice/LoginServiceImpl.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/LoginServiceImpl.java
@@ -22,14 +22,14 @@ public class LoginServiceImpl implements LoginService {
 
     @Override
     public LoginResponseDto login(LoginRequestDto requestDto, HttpServletResponse response) {
-        ResponseEntity<AdminLoginResponseDto> responseEntity = authServiceClient.login(AdminLoginRequestDto.of(requestDto.getId(), requestDto.getPassword()));
-        AdminLoginResponseDto user = responseEntity.getBody();
+        ResponseEntity<AdminLoginResponseDto> feignResponse = authServiceClient.login(AdminLoginRequestDto.of(requestDto.getId(), requestDto.getPassword()));
+        AdminLoginResponseDto user = feignResponse.getBody();
 
         assertNotNull(requestDto, user);
         AdminRoleUtils.checkRole(user.getRole());
 
-        this.addHeaders(responseEntity, response);
-        return LoginResponseDto.of(user.getName(), user.getRole());
+        this.addHeaders(feignResponse, response);
+        return LoginResponseDto.of(feignResponse.getBody().getName(), feignResponse.getBody().getRole());
     }
 
     private void assertNotNull(LoginRequestDto requestDto, AdminLoginResponseDto user) {
@@ -39,7 +39,7 @@ public class LoginServiceImpl implements LoginService {
         }
     }
 
-    private void addHeaders(ResponseEntity<AdminLoginResponseDto> feignResponse, HttpServletResponse response) {
+    private void addHeaders(ResponseEntity<?> feignResponse, HttpServletResponse response) {
         final String HEADER_ACCESS = "access";
         final String HEADER_REFRESH = "refresh";
         String accessToken = feignResponse.getHeaders().getOrDefault(HEADER_ACCESS, null).get(0);


### PR DESCRIPTION
## 이슈.

로그인 `401`에 대한 Response의 body에 null이 들어있는 것을 확인.

해결을 위해 feign 깃허브를 훔쳐봤지만, 거기서도 해당 문제에 대해서 이슈를 다뤘지만, 아직 존재하는 것으로 확인.

또다른 해결방법이 있는지는 모르지만, 일단 `401` 발생 시 `ADMIN` 서버의 `FeignUnauthorizedException`을 발생시키고, Response body를 사용하지 않음으로 해결하였음.

END. ISSUE.