### PR TITLE
[관리자] 작가 포트폴리오 이미지 추가,조회

### DIFF
--- a/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
@@ -172,9 +172,10 @@ public interface ProductServiceClient {
     /** 라이센스 이미지 추가*/
     @PostMapping(value = "/admin/licenseImage", consumes = "multipart/form-data")
     @ResponseStatus(HttpStatus.CREATED)
-	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto, MultipartFile productIntroductionImageFile);
+	void createLicenseImageByAdmin(@RequestHeader("LB-Role") String role, @RequestPart("dto") String dtoJson,
+		@RequestPart(value = "image") MultipartFile productIntroductionImageFile);
     /** 라이센스 이미지 조회*/
     @GetMapping("/admin/licenseImage")
     @ResponseStatus(HttpStatus.OK)
-    List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(String role);
+    List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(@RequestHeader("LB-Role")String role);
 }

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
@@ -169,4 +169,8 @@ public interface ProductServiceClient {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void modifyProductIntroductionByAdmin(@RequestHeader("LB-Role") String role, @PathVariable String productId,
                                           @RequestPart(value = "images",required = false) MultipartFile productIntroductionImageFile);
+    /** 라이센스 이미지 추가*/
+    @PostMapping(value = "/admin/licenseImage", consumes = "multipart/form-data")
+    @ResponseStatus(HttpStatus.CREATED)
+	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto, MultipartFile productIntroductionImageFile);
 }

--- a/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
+++ b/src/main/java/com/liberty52/admin/global/adapter/feign/ProductServiceClient.java
@@ -173,4 +173,8 @@ public interface ProductServiceClient {
     @PostMapping(value = "/admin/licenseImage", consumes = "multipart/form-data")
     @ResponseStatus(HttpStatus.CREATED)
 	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto, MultipartFile productIntroductionImageFile);
+    /** 라이센스 이미지 조회*/
+    @GetMapping("/admin/licenseImage")
+    @ResponseStatus(HttpStatus.OK)
+    List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(String role);
 }

--- a/src/main/java/com/liberty52/admin/global/config/JacksonConfig.java
+++ b/src/main/java/com/liberty52/admin/global/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package com.liberty52.admin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+}

--- a/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageCreateService.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageCreateService.java
@@ -1,0 +1,9 @@
+package com.liberty52.admin.service.applicationservice;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.liberty52.admin.service.controller.dto.LicenseImageCreateDto;
+
+public interface LicenseImageCreateService {
+	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto, MultipartFile productIntroductionImageFile);
+}

--- a/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageCreateService.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageCreateService.java
@@ -1,9 +1,12 @@
 package com.liberty52.admin.service.applicationservice;
 
+import java.io.IOException;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import com.liberty52.admin.service.controller.dto.LicenseImageCreateDto;
 
 public interface LicenseImageCreateService {
-	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto, MultipartFile productIntroductionImageFile);
+	void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto,
+		MultipartFile productIntroductionImageFile) throws IOException;
 }

--- a/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageRetrieveService.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/LicenseImageRetrieveService.java
@@ -1,0 +1,9 @@
+package com.liberty52.admin.service.applicationservice;
+
+import java.util.List;
+
+import com.liberty52.admin.service.controller.dto.LicenseImageRetrieveDto;
+
+public interface LicenseImageRetrieveService {
+	List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(String role);
+}

--- a/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageCreateServiceImpl.java
@@ -3,6 +3,8 @@ package com.liberty52.admin.service.applicationservice.impl;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liberty52.admin.global.adapter.feign.ProductServiceClient;
 import com.liberty52.admin.service.applicationservice.LicenseImageCreateService;
 import com.liberty52.admin.service.controller.dto.LicenseImageCreateDto;
@@ -13,9 +15,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LicenseImageCreateServiceImpl implements LicenseImageCreateService {
 	private final ProductServiceClient productServiceClient;
+	private final ObjectMapper objectMapper;
+
 	@Override
 	public void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto,
-		MultipartFile productIntroductionImageFile) {
-		productServiceClient.createLicenseImageByAdmin(role, dto, productIntroductionImageFile);
+		MultipartFile productIntroductionImageFile) throws JsonProcessingException {
+		String dtoJson = objectMapper.writeValueAsString(dto);
+		productServiceClient.createLicenseImageByAdmin(role, dtoJson, productIntroductionImageFile);
 	}
 }

--- a/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageCreateServiceImpl.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageCreateServiceImpl.java
@@ -1,0 +1,21 @@
+package com.liberty52.admin.service.applicationservice.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.liberty52.admin.global.adapter.feign.ProductServiceClient;
+import com.liberty52.admin.service.applicationservice.LicenseImageCreateService;
+import com.liberty52.admin.service.controller.dto.LicenseImageCreateDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LicenseImageCreateServiceImpl implements LicenseImageCreateService {
+	private final ProductServiceClient productServiceClient;
+	@Override
+	public void createLicenseImageByAdmin(String role, LicenseImageCreateDto dto,
+		MultipartFile productIntroductionImageFile) {
+		productServiceClient.createLicenseImageByAdmin(role, dto, productIntroductionImageFile);
+	}
+}

--- a/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageRetrieveServiceImpl.java
+++ b/src/main/java/com/liberty52/admin/service/applicationservice/impl/LicenseImageRetrieveServiceImpl.java
@@ -1,0 +1,21 @@
+package com.liberty52.admin.service.applicationservice.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.liberty52.admin.global.adapter.feign.ProductServiceClient;
+import com.liberty52.admin.service.applicationservice.LicenseImageRetrieveService;
+import com.liberty52.admin.service.controller.dto.LicenseImageRetrieveDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LicenseImageRetrieveServiceImpl implements LicenseImageRetrieveService {
+	private final ProductServiceClient productServiceClient;
+	@Override
+	public List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(String role) {
+		return productServiceClient.retrieveLicenseImageByAdmin(role);
+	}
+}

--- a/src/main/java/com/liberty52/admin/service/controller/LicenseImageCreateController.java
+++ b/src/main/java/com/liberty52/admin/service/controller/LicenseImageCreateController.java
@@ -1,0 +1,29 @@
+package com.liberty52.admin.service.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.liberty52.admin.service.applicationservice.LicenseImageCreateService;
+import com.liberty52.admin.service.controller.dto.LicenseImageCreateDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class LicenseImageCreateController {
+	private final LicenseImageCreateService licenseImageCreateService;
+
+	@PostMapping("/licenseImage")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createLicenseImageByAdmin(@RequestHeader("LB-Role") String role,
+		@Validated @RequestPart("dto") LicenseImageCreateDto dto,
+		@RequestPart(value = "images", required = false) MultipartFile productIntroductionImageFile) {
+		licenseImageCreateService.createLicenseImageByAdmin(role, dto, productIntroductionImageFile);
+	}
+}

--- a/src/main/java/com/liberty52/admin/service/controller/LicenseImageCreateController.java
+++ b/src/main/java/com/liberty52/admin/service/controller/LicenseImageCreateController.java
@@ -1,5 +1,7 @@
 package com.liberty52.admin.service.controller;
 
+import java.io.IOException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +25,7 @@ public class LicenseImageCreateController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public void createLicenseImageByAdmin(@RequestHeader("LB-Role") String role,
 		@Validated @RequestPart("dto") LicenseImageCreateDto dto,
-		@RequestPart(value = "images", required = false) MultipartFile productIntroductionImageFile) {
+		@RequestPart(value = "image") MultipartFile productIntroductionImageFile) throws IOException {
 		licenseImageCreateService.createLicenseImageByAdmin(role, dto, productIntroductionImageFile);
 	}
 }

--- a/src/main/java/com/liberty52/admin/service/controller/LicenseImageRetrieveController.java
+++ b/src/main/java/com/liberty52/admin/service/controller/LicenseImageRetrieveController.java
@@ -1,0 +1,26 @@
+package com.liberty52.admin.service.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.liberty52.admin.service.applicationservice.LicenseImageRetrieveService;
+import com.liberty52.admin.service.controller.dto.LicenseImageRetrieveDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class LicenseImageRetrieveController {
+	private final LicenseImageRetrieveService licenseImageRetrieveService;
+
+	@GetMapping("/licenseImage")
+	@ResponseStatus(HttpStatus.OK)
+	public List<LicenseImageRetrieveDto> retrieveLicenseImageByAdmin(@RequestHeader("LB-Role") String role) {
+		return licenseImageRetrieveService.retrieveLicenseImageByAdmin(role);
+	}
+}

--- a/src/main/java/com/liberty52/admin/service/controller/dto/LicenseImageCreateDto.java
+++ b/src/main/java/com/liberty52/admin/service/controller/dto/LicenseImageCreateDto.java
@@ -1,0 +1,24 @@
+package com.liberty52.admin.service.controller.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LicenseImageCreateDto {
+	@NotBlank
+	private String artistName;
+	@NotBlank
+	private String artName;
+	@NotNull
+	private LocalDate startDate;
+	@NotNull
+	private LocalDate endDate;
+	@Min(0)
+	private Integer stock;
+}

--- a/src/main/java/com/liberty52/admin/service/controller/dto/LicenseImageRetrieveDto.java
+++ b/src/main/java/com/liberty52/admin/service/controller/dto/LicenseImageRetrieveDto.java
@@ -1,0 +1,21 @@
+package com.liberty52.admin.service.controller.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseImageRetrieveDto {
+	private String id;
+	private String artistName;
+	private String artName;
+	private LocalDate startDate;
+	private LocalDate endDate;
+	private String licenseImageUrl;
+	private Integer stock;
+
+}


### PR DESCRIPTION
## 스프린트 넘버  : 2
Close #84

### 작업
- 관리자  작가 포트폴리오 이미지 추가
- 관리자  작가 포트폴리오 이미지 조회
- feign을 사용하여 multiPartFile과 dto를 동시에 보내기 위해 dto를 json화 시킨 후 product 로 보낸 뒤 다시 dto로 매핑하는 방식을 사용
- dto 데이터 중 LocalDate, LocalDateTime 객체를 json 처리하기 위해  Jackson config를 추가

### 테스트 결과
![image](https://github.com/Liberty52/admin/assets/55132026/4d7bae9f-dbcd-4182-a818-27741b90adb6)
![image](https://github.com/Liberty52/admin/assets/55132026/1959ecc5-d852-4c8e-b509-3c6e32ad4693)

